### PR TITLE
fix: overlay spinner without blocking pointer events

### DIFF
--- a/components/SpeckleViewer.tsx
+++ b/components/SpeckleViewer.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import '@speckle/viewer'
 
 export interface SpeckleViewerProps {
@@ -12,13 +12,34 @@ const SpeckleViewer: React.FC<SpeckleViewerProps> = ({
   modelId,
   token
 }) => {
+  const ref = useRef<HTMLElement | null>(null)
+  const [loaded, setLoaded] = useState(false)
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+
+    setLoaded(false)
+    const handleLoad = () => setLoaded(true)
+    el.addEventListener('load-complete', handleLoad)
+    return () => el.removeEventListener('load-complete', handleLoad)
+  }, [streamId, modelId])
+
   return (
-    <viewer-container
-      style={{ width: '100%', height: '100%' }}
-      streamId={streamId}
-      modelId={modelId}
-      token={token}
-    />
+    <div className="relative w-full h-full">
+      {!loaded && (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-white/50">
+          <div className="h-8 w-8 animate-spin rounded-full border-4 border-neutral-300 border-t-transparent" />
+        </div>
+      )}
+      <viewer-container
+        ref={ref}
+        style={{ width: '100%', height: '100%' }}
+        streamId={streamId}
+        modelId={modelId}
+        token={token}
+      />
+    </div>
   )
 }
 


### PR DESCRIPTION
## Summary
- ensure loading spinner overlay is non-interactive

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68551a3259308322b6ff5950d0830173