### PR TITLE
feat: add vertical sidebar nav

### DIFF
--- a/__tests__/sidebar-nav.test.tsx
+++ b/__tests__/sidebar-nav.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react'
+import SidebarNav from '../components/sidebar-nav'
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => '/'
+}))
+
+test('renders nav links', () => {
+  render(<SidebarNav />)
+  expect(screen.getByLabelText(/dashboard/i)).toBeInTheDocument()
+  expect(screen.getByLabelText(/projects/i)).toBeInTheDocument()
+  expect(screen.getByLabelText(/compare/i)).toBeInTheDocument()
+})

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -1,0 +1,3 @@
+export default function ComparePage() {
+  return <h1 className="text-xl font-semibold">Compare</h1>
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,10 +1,16 @@
-import './globals.css';
-import type { ReactNode } from 'react';
+import './globals.css'
+import type { ReactNode } from 'react'
+import SidebarNav from '@/components/sidebar-nav'
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body className="font-sans antialiased">{children}</body>
+      <body className="font-sans antialiased">
+        <div className="flex min-h-screen">
+          <SidebarNav />
+          <main className="flex-1 p-4">{children}</main>
+        </div>
+      </body>
     </html>
-  );
+  )
 }

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,0 +1,3 @@
+export default function ProjectsPage() {
+  return <h1 className="text-xl font-semibold">Projects</h1>
+}

--- a/components/sidebar-nav.tsx
+++ b/components/sidebar-nav.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { LayoutDashboard, FolderKanban, GitCompare } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+const links = [
+  { href: '/', label: 'Dashboard', icon: LayoutDashboard },
+  { href: '/projects', label: 'Projects', icon: FolderKanban },
+  { href: '/compare', label: 'Compare', icon: GitCompare },
+]
+
+export default function SidebarNav() {
+  const pathname = usePathname()
+
+  return (
+    <nav aria-label="Main" className="flex h-full w-16 flex-col items-center gap-4 border-r p-4">
+      <Link href="/" className="mb-4 font-semibold focus:outline-none focus-visible:ring-2 focus-visible:ring-ring" aria-label="Home">
+        CC
+      </Link>
+      <ul className="flex flex-col gap-3">
+        {links.map(({ href, label, icon: Icon }) => (
+          <li key={href}>
+            <Link
+              href={href}
+              aria-label={label}
+              className={cn(
+                'flex flex-col items-center rounded-md p-2 text-muted-foreground hover:bg-accent hover:text-accent-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                pathname === href && 'bg-accent text-accent-foreground'
+              )}
+            >
+              <Icon aria-hidden="true" className="size-5" />
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  )
+}


### PR DESCRIPTION
## Summary
- add lucide-powered sidebar nav
- scaffold compare and projects routes
- style layout with sidebar
- test sidebar links

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_685520f1fa0083229b8c9b07b2b7a430