### PR TITLE
Add design option drawer

### DIFF
--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -1,6 +1,9 @@
-import { Suspense } from "react";
-import { useSearchParams } from "next/navigation";
-import { Viewer } from "@speckle/viewer-react";
+'use client';
+
+import { Suspense } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { Viewer } from '@speckle/viewer-react';
+import OptionDrawer from '@/components/option-drawer';
 
 interface ProjectPageProps {
   params: { id: string };
@@ -8,14 +11,20 @@ interface ProjectPageProps {
 
 export default function ProjectPage({ params }: ProjectPageProps) {
   const searchParams = useSearchParams();
-  const streamId = searchParams.get("streamId") ?? "";
+  const streamId = searchParams.get('streamId') ?? '';
+  const optionId = searchParams.get('optionId') ?? '';
 
   return (
-    <main className="flex flex-col gap-4">
+    <main className="relative flex flex-col gap-4">
       <h1 className="text-xl font-semibold">Hello Project</h1>
+      <OptionDrawer />
       {streamId && (
         <Suspense fallback={null}>
-          <Viewer streamId={streamId} className="w-full h-[80vh]" />
+          <Viewer
+            key={optionId}
+            streamId={streamId}
+            className="w-full h-[80vh]"
+          />
         </Suspense>
       )}
     </main>

--- a/components/option-drawer.tsx
+++ b/components/option-drawer.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+
+const options = [
+  { id: 'option-a', name: 'Option A' },
+  { id: 'option-b', name: 'Option B' },
+  { id: 'option-c', name: 'Option C' },
+];
+
+export default function OptionDrawer() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [open, setOpen] = useState(false);
+  const optionId = searchParams.get('optionId') ?? '';
+
+  const setOption = (id: string) => {
+    const params = new URLSearchParams(Array.from(searchParams.entries()));
+    params.set('optionId', id);
+    router.push(`?${params.toString()}`, { scroll: false });
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <Button
+        variant="secondary"
+        className="self-end"
+        onClick={() => setOpen(!open)}
+      >
+        {open ? 'Close options' : 'Design options'}
+      </Button>
+      {open && (
+        <aside className="fixed right-0 top-0 z-50 flex h-full w-64 flex-col gap-2 overflow-y-auto border-l bg-background p-4 shadow-lg">
+          <h2 className="text-lg font-semibold">Design Options</h2>
+          <ul className="flex flex-col gap-2">
+            {options.map((opt) => (
+              <li key={opt.id}>
+                <Button
+                  className="w-full justify-start"
+                  variant={opt.id === optionId ? 'default' : 'outline'}
+                  onClick={() => setOption(opt.id)}
+                >
+                  {opt.name}
+                </Button>
+              </li>
+            ))}
+          </ul>
+        </aside>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add option drawer component listing design options
- update project page to show drawer and reload viewer on option change

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6855230a7c9c8322a0087abf4eed431c