### PR TITLE
feat: add carbon chart hook

### DIFF
--- a/hooks/use-carbon-chart.tsx
+++ b/hooks/use-carbon-chart.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import React from 'react';
+import ReactECharts from 'echarts-for-react';
+
+export type CarbonChartType = 'bar' | 'radar' | 'gauge';
+
+interface BarData {
+  categories: string[];
+  values: number[];
+}
+
+interface RadarData {
+  indicators: { name: string; max: number }[];
+  values: number[];
+}
+
+interface GaugeData {
+  value: number;
+}
+
+type ChartData = BarData | RadarData | GaugeData;
+
+export default function useCarbonChart(type: CarbonChartType, data: ChartData) {
+  const option = React.useMemo(() => {
+    switch (type) {
+      case 'bar': {
+        const d = data as BarData;
+        return {
+          xAxis: { type: 'category', data: d.categories },
+          yAxis: { type: 'value' },
+          series: [{ type: 'bar', data: d.values }],
+        };
+      }
+      case 'radar': {
+        const d = data as RadarData;
+        return {
+          radar: { indicator: d.indicators },
+          series: [{ type: 'radar', data: [{ value: d.values }] }],
+        };
+      }
+      case 'gauge': {
+        const d = data as GaugeData;
+        return {
+          series: [
+            {
+              type: 'gauge',
+              progress: { show: true },
+              detail: { formatter: '{value}%' },
+              data: [{ value: d.value }],
+            },
+          ],
+        };
+      }
+      default:
+        return {};
+    }
+  }, [type, data]);
+
+  return <ReactECharts option={option} />;
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "@radix-ui/react-tooltip": "^1.2.7",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "echarts": "^5.6.0",
+    "echarts-for-react": "^3.0.2",
     "lucide-react": "^0.518.0",
     "next": "14.0.4",
     "react": "18.2.0",


### PR DESCRIPTION
## Summary
- install `echarts` and `echarts-for-react`
- add `useCarbonChart` hook for bar, radar and gauge charts

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_685527ecbf908322a5b8ab26edada45a