### PR TITLE
docs: provide env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_API_URL=http://localhost:3001
+SPECKLE_SERVER_URL=https://speckle.example.com

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 npm-debug.log*
 .env.local
 .env.*
+!.env.example
 coverage/
 tsconfig.tsbuildinfo
 package-lock.json


### PR DESCRIPTION
## Summary
- add `.env.example` for API URL configuration
- allow `.env.example` through `.gitignore`

## Testing
- `npm run lint`
- `npm test`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_b_6855487e101083229923534a45ba456c