### PR TITLE
feat: add local tRPC hooks

### DIFF
--- a/hooks/use-api.ts
+++ b/hooks/use-api.ts
@@ -1,0 +1,28 @@
+'use client';
+
+import { useEffect } from 'react';
+import { trpc } from '@/lib/trpc';
+
+export function useProjects() {
+  const [data] = trpc.projects.useSuspenseQuery();
+  useEffect(() => {
+    console.log('projects', data);
+  }, [data]);
+  return data;
+}
+
+export function useOptions(projectId: string) {
+  const [data] = trpc.options.useSuspenseQuery({ projectId });
+  useEffect(() => {
+    console.log('options', data);
+  }, [data]);
+  return data;
+}
+
+export function useCarbonResults(optionId: string) {
+  const [data] = trpc.carbonResults.useSuspenseQuery({ optionId });
+  useEffect(() => {
+    console.log('results', data);
+  }, [data]);
+  return data;
+}

--- a/lib/mock-router.ts
+++ b/lib/mock-router.ts
@@ -1,0 +1,58 @@
+import { initTRPC } from '@trpc/server';
+
+const t = initTRPC.create();
+
+export interface Project {
+  id: string;
+  name: string;
+}
+
+export interface Option {
+  id: string;
+  projectId: string;
+  name: string;
+}
+
+export interface CarbonResult {
+  optionId: string;
+  value: number;
+}
+
+const projects: Project[] = [
+  { id: 'p1', name: 'Circular House' },
+  { id: 'p2', name: 'Metro Station' },
+];
+
+const options: Option[] = [
+  { id: 'o1', projectId: 'p1', name: 'Option A' },
+  { id: 'o2', projectId: 'p1', name: 'Option B' },
+  { id: 'o3', projectId: 'p2', name: 'Option A' },
+];
+
+const results: CarbonResult[] = [
+  { optionId: 'o1', value: 100 },
+  { optionId: 'o2', value: 85 },
+  { optionId: 'o3', value: 120 },
+];
+
+export const appRouter = t.router({
+  projects: t.procedure.query(() => projects),
+  options: t.procedure
+    .input((val: unknown) => {
+      if (typeof val === 'object' && val && 'projectId' in val) {
+        return { projectId: String((val as any).projectId) };
+      }
+      throw new Error('Invalid input');
+    })
+    .query(({ input }) => options.filter(o => o.projectId === input.projectId)),
+  carbonResults: t.procedure
+    .input((val: unknown) => {
+      if (typeof val === 'object' && val && 'optionId' in val) {
+        return { optionId: String((val as any).optionId) };
+      }
+      throw new Error('Invalid input');
+    })
+    .query(({ input }) => results.filter(r => r.optionId === input.optionId)),
+});
+
+export type AppRouter = typeof appRouter;

--- a/lib/trpc.ts
+++ b/lib/trpc.ts
@@ -1,12 +1,15 @@
 import { createTRPCReact } from '@trpc/react-query';
-import { httpBatchLink } from '@trpc/client';
+import { experimental_localLink } from '@trpc/client';
+import type { AppRouter } from './mock-router';
+import { appRouter } from './mock-router';
 
-export const trpc = createTRPCReact();
+export const trpc = createTRPCReact<AppRouter>();
 
 export const trpcClient = trpc.createClient({
   links: [
-    httpBatchLink({
-      url: `${process.env.NEXT_PUBLIC_API_URL ?? ''}/trpc`,
+    experimental_localLink({
+      router: appRouter,
+      createContext: () => ({}),
     }),
   ],
 });


### PR DESCRIPTION
## Summary
- add a mock tRPC router with sample data
- configure trpc client to use the local link
- expose typed hooks `useProjects`, `useOptions` and `useCarbonResults`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68554dc0a8c48322b5e700f6fd298df8