### PR TITLE
Add Suspense with skeleton placeholders

### DIFF
--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, Suspense } from 'react';
 import useCarbonChart from '@/hooks/use-carbon-chart';
+import { Skeleton } from '@/components/ui/skeleton';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
 const metrics = [
@@ -62,13 +63,21 @@ export default function ComparePage() {
           <CardHeader>
             <CardTitle>{current.leftLabel}</CardTitle>
           </CardHeader>
-          <CardContent>{leftChart}</CardContent>
+          <CardContent>
+            <Suspense fallback={<Skeleton className="h-64 w-full" />}>
+              {leftChart}
+            </Suspense>
+          </CardContent>
         </Card>
         <Card>
           <CardHeader>
             <CardTitle>{current.rightLabel}</CardTitle>
           </CardHeader>
-          <CardContent>{rightChart}</CardContent>
+          <CardContent>
+            <Suspense fallback={<Skeleton className="h-64 w-full" />}>
+              {rightChart}
+            </Suspense>
+          </CardContent>
         </Card>
       </div>
       <table className="w-full table-auto text-sm">

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -1,8 +1,14 @@
 'use client';
 
 import { Suspense } from 'react';
+import dynamic from 'next/dynamic';
 import { useSearchParams } from 'next/navigation';
-import { Viewer } from '@speckle/viewer-react';
+import { Skeleton } from '@/components/ui/skeleton';
+
+const Viewer = dynamic(() => import('@speckle/viewer-react').then(m => m.Viewer), {
+  ssr: false,
+  suspense: true,
+});
 import OptionDrawer from '@/components/option-drawer';
 
 interface ProjectPageProps {
@@ -19,7 +25,7 @@ export default function ProjectPage({ params }: ProjectPageProps) {
       <h1 className="text-xl font-semibold">Hello Project</h1>
       <OptionDrawer />
       {streamId && (
-        <Suspense fallback={null}>
+        <Suspense fallback={<Skeleton className="h-[80vh] w-full" />}>
           <Viewer
             key={optionId}
             streamId={streamId}

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export interface SkeletonProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+const Skeleton = React.forwardRef<HTMLDivElement, SkeletonProps>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      {...props}
+    />
+  )
+)
+Skeleton.displayName = "Skeleton"
+
+export { Skeleton }

--- a/hooks/use-carbon-chart.tsx
+++ b/hooks/use-carbon-chart.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import ReactECharts from 'echarts-for-react';
+const ReactECharts = React.lazy(() => import('echarts-for-react'));
 
 export type CarbonChartType = 'bar' | 'radar' | 'gauge';
 


### PR DESCRIPTION
## Summary
- add shadcn `Skeleton` component
- lazy load Speckle viewer with Suspense fallback
- wrap charts in Suspense when loading ECharts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68555e9c91188322a38cc260c4f4cef7