### PR TITLE
feat: add theme provider and toggle

### DIFF
--- a/__tests__/sidebar-nav.test.tsx
+++ b/__tests__/sidebar-nav.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react'
+import { ThemeProvider } from 'next-themes'
 import SidebarNav from '../components/sidebar-nav'
 
 jest.mock('next/navigation', () => ({
@@ -6,7 +7,11 @@ jest.mock('next/navigation', () => ({
 }))
 
 test('renders nav links', () => {
-  render(<SidebarNav />)
+  render(
+    <ThemeProvider attribute="class" defaultTheme="light">
+      <SidebarNav />
+    </ThemeProvider>
+  )
   expect(screen.getByLabelText(/dashboard/i)).toBeInTheDocument()
   expect(screen.getByLabelText(/projects/i)).toBeInTheDocument()
   expect(screen.getByLabelText(/compare/i)).toBeInTheDocument()

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,7 +5,7 @@ import Providers from '@/components/providers';
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body className="font-sans antialiased">
         <Providers>
           <div className="flex min-h-screen">

--- a/components/providers.tsx
+++ b/components/providers.tsx
@@ -1,14 +1,17 @@
 'use client';
 
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ReactNode, useState } from 'react';
-import { trpc, trpcClient } from '@/lib/trpc';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ReactNode, useState } from 'react'
+import { ThemeProvider } from 'next-themes'
+import { trpc, trpcClient } from '@/lib/trpc'
 
 export default function Providers({ children }: { children: ReactNode }) {
   const [queryClient] = useState(() => new QueryClient());
   return (
-    <trpc.Provider client={trpcClient} queryClient={queryClient}>
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    </trpc.Provider>
+    <ThemeProvider attribute="class" defaultTheme="light">
+      <trpc.Provider client={trpcClient} queryClient={queryClient}>
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      </trpc.Provider>
+    </ThemeProvider>
   );
 }

--- a/components/sidebar-nav.tsx
+++ b/components/sidebar-nav.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { LayoutDashboard, FolderKanban, GitCompare } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import ThemeToggle from '@/components/theme-toggle'
 
 const links = [
   { href: '/', label: 'Dashboard', icon: LayoutDashboard },
@@ -35,6 +36,7 @@ export default function SidebarNav() {
           </li>
         ))}
       </ul>
+      <ThemeToggle />
     </nav>
   )
 }

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import { useTheme } from 'next-themes'
+import { Moon, Sun } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+export default function ThemeToggle() {
+  const { resolvedTheme, setTheme } = useTheme()
+  const isDark = resolvedTheme === 'dark'
+  return (
+    <Button
+      variant="ghost"
+      aria-label="Toggle theme"
+      onClick={() => setTheme(isDark ? 'light' : 'dark')}
+      className="mt-auto"
+    >
+      {isDark ? (
+        <Sun aria-hidden="true" className="size-5" />
+      ) : (
+        <Moon aria-hidden="true" className="size-5" />
+      )}
+    </Button>
+  )
+}

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,1 +1,15 @@
 import '@testing-library/jest-dom';
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }),
+});

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "echarts-for-react": "^3.0.2",
     "lucide-react": "^0.518.0",
     "next": "14.0.4",
+    "next-themes": "^0.4.6",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "tailwind-merge": "^3.3.1",


### PR DESCRIPTION
## Summary
- add next-themes dependency and ThemeProvider wrapper
- create ThemeToggle button
- include toggle in sidebar
- enable hydration suppression for theme
- polyfill `matchMedia` for Jest tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_685560367e20832283a3e91c34493c24