### PR TITLE
feat: animate page transitions

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import './globals.css';
 import type { ReactNode } from 'react';
 import SidebarNav from '@/components/sidebar-nav';
 import Providers from '@/components/providers';
+import PageTransition from '@/components/page-transition';
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
@@ -10,7 +11,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <Providers>
           <div className="flex min-h-screen">
             <SidebarNav />
-            <main className="flex-1 p-4">{children}</main>
+            <PageTransition>{children}</PageTransition>
           </div>
         </Providers>
       </body>

--- a/components/page-transition.tsx
+++ b/components/page-transition.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import { ReactNode } from 'react'
+import { AnimatePresence, motion } from 'framer-motion'
+
+export default function PageTransition({ children }: { children: ReactNode }) {
+  const pathname = usePathname()
+  return (
+    <AnimatePresence mode="wait">
+      <motion.main
+        key={pathname}
+        initial={{ opacity: 0, x: 20 }}
+        animate={{ opacity: 1, x: 0 }}
+        exit={{ opacity: 0, x: -20 }}
+        transition={{ duration: 0.3 }}
+        className="flex-1 p-4"
+      >
+        {children}
+      </motion.main>
+    </AnimatePresence>
+  )
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "clsx": "^2.1.1",
     "echarts": "^5.6.0",
     "echarts-for-react": "^3.0.2",
+    "framer-motion": "^12.18.1",
     "lucide-react": "^0.518.0",
     "next": "14.0.4",
     "next-themes": "^0.4.6",


### PR DESCRIPTION
## Summary
- animate page transitions
- use Framer Motion via PageTransition wrapper

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_685561a87090832285f12d6b3a2be117