### PR TITLE
Add jsx-a11y linting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
-  "extends": ["next/core-web-vitals", "prettier"],
-  "plugins": ["@typescript-eslint"],
+  "extends": ["next/core-web-vitals", "plugin:jsx-a11y/recommended", "prettier"],
+  "plugins": ["@typescript-eslint", "jsx-a11y"],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaVersion": 2020,

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint": "^8.0.0",
     "eslint-config-next": "^15.0.0",
     "eslint-config-prettier": "^9.0.0",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
     "jest": "^29.0.0",
     "jest-environment-jsdom": "^29.5.0",
     "postcss": "^8.4.0",


### PR DESCRIPTION
## Summary
- add `eslint-plugin-jsx-a11y` as dev dependency
- extend eslint config with recommended jsx-a11y rules

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_685564e707ac832289f9a2a0caabcd44