### PR TITLE
Add collapsible sidebar and landing grid

### DIFF
--- a/__tests__/app.test.tsx
+++ b/__tests__/app.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import Page from '../app/page';
 
-test('renders heading', () => {
+test('renders project cards', () => {
   render(<Page />);
-  expect(screen.getByRole('heading', { name: /carbon101/i })).toBeInTheDocument();
+  expect(screen.getAllByRole('link', { name: /enter/i }).length).toBeGreaterThan(0);
 });

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,6 @@
 import './globals.css';
 import type { ReactNode } from 'react';
-import SidebarNav from '@/components/sidebar-nav';
+import Sidebar from '@/components/Sidebar';
 import Providers from '@/components/providers';
 import PageTransition from '@/components/page-transition';
 
@@ -10,7 +10,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       <body className="font-sans antialiased">
         <Providers>
           <div className="flex min-h-screen">
-            <SidebarNav />
+            <Sidebar />
             <PageTransition>{children}</PageTransition>
           </div>
         </Providers>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,25 @@
-export default function Page() {
-  return <h1 className="text-2xl font-bold">Carbon101</h1>;
-}
+import Link from 'next/link';
+import { Card, CardContent, CardFooter } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
 
+const projects = ['Project A', 'Project B', 'Project C'];
+
+export default function Page() {
+  return (
+    <div className="grid gap-4 p-4 sm:grid-cols-2 lg:grid-cols-3">
+      {projects.map((name, i) => (
+        <Card key={name}>
+          <CardContent className="flex h-32 items-center justify-center bg-muted">
+            <span className="text-sm text-muted-foreground">Thumbnail {i + 1}</span>
+          </CardContent>
+          <CardFooter className="justify-between">
+            <span className="font-medium">{name}</span>
+            <Button asChild size="sm">
+              <Link href={`/projects/${i}`}>Enter</Link>
+            </Button>
+          </CardFooter>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { User, Settings, ChevronLeft, ChevronRight } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+const projects = ['Project A', 'Project B', 'Project C'];
+
+export default function Sidebar() {
+  const [open, setOpen] = useState(true);
+  return (
+    <aside
+      className={cn(
+        'flex flex-col border-r transition-all',
+        open ? 'w-56' : 'w-16'
+      )}
+    >
+      <div className="flex items-center justify-between p-4">
+        <User aria-hidden="true" className="size-6" />
+        <button
+          aria-label="Toggle sidebar"
+          onClick={() => setOpen(!open)}
+          className="rounded p-1 hover:bg-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {open ? (
+            <ChevronLeft aria-hidden="true" className="size-5" />
+          ) : (
+            <ChevronRight aria-hidden="true" className="size-5" />
+          )}
+        </button>
+      </div>
+      <nav className="flex-1 overflow-y-auto px-2">
+        {open && (
+          <h2 className="mb-2 px-2 text-sm font-semibold text-muted-foreground">
+            Projects
+          </h2>
+        )}
+        <ul className="space-y-1">
+          {projects.map((name) => (
+            <li key={name}>
+              <Link
+                href="#"
+                className={cn(
+                  'block rounded px-2 py-1 text-sm hover:bg-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                  !open && 'text-center'
+                )}
+              >
+                {open ? name : name.charAt(0)}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </nav>
+      <div className="p-4 mt-auto">
+        <Settings aria-hidden="true" className="size-5" />
+      </div>
+    </aside>
+  );
+}


### PR DESCRIPTION
## Summary
- create `Sidebar` component with collapse behaviour
- integrate new sidebar in layout
- show grid of project cards on landing page
- update app test for new home page

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68556a3b0928832293f4a62f85a0eab8