### PR TITLE
Add draggable compare tabs

### DIFF
--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -1,116 +1,42 @@
-'use client';
+'use client'
 
-import { useState, Suspense } from 'react';
-import useCarbonChart from '@/hooks/use-carbon-chart';
-import { Skeleton } from '@/components/ui/skeleton';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import DraggableTabs, { TabItem } from '@/components/DraggableTabs'
+import StackedBarChart, { Series } from '@/components/StackedBarChart'
 
-const metrics = [
-  { name: 'A1-A3', max: 100 },
-  { name: 'A4', max: 100 },
-  { name: 'A5', max: 100 },
-];
+const categories = ['A1-A3', 'A4', 'A5']
 
-const datasets = [
-  {
-    id: 'set1',
-    name: 'Concept set 1',
-    leftLabel: 'Option A',
-    rightLabel: 'Option B',
-    left: { indicators: metrics, values: [40, 20, 10] },
-    right: { indicators: metrics, values: [35, 25, 15] },
-  },
-  {
-    id: 'set2',
-    name: 'Concept set 2',
-    leftLabel: 'Option C',
-    rightLabel: 'Option D',
-    left: { indicators: metrics, values: [50, 30, 20] },
-    right: { indicators: metrics, values: [45, 35, 25] },
-  },
-];
+function makeSeries(): Series[] {
+  return [
+    { name: 'Concrete', values: categories.map(() => Math.floor(Math.random() * 40 + 10)) },
+    { name: 'Steel', values: categories.map(() => Math.floor(Math.random() * 20 + 5)) },
+  ]
+}
 
 export default function ComparePage() {
-  const [current, setCurrent] = useState(datasets[0]);
-  const leftChart = useCarbonChart('radar', current.left);
-  const rightChart = useCarbonChart('radar', current.right);
+  const [tabs, setTabs] = useState<TabItem[]>([
+    { id: 'tab-1', title: 'Option 1', content: <StackedBarChart categories={categories} series={makeSeries()} /> },
+  ])
 
-  const rows = current.left.indicators.map((m, i) => {
-    const a = current.left.values[i];
-    const b = current.right.values[i];
-    const diff = ((b - a) / a) * 100;
-    return { name: m.name, a, b, diff };
-  });
+  const addTab = () => {
+    const next: TabItem = {
+      id: `tab-${Date.now()}`,
+      title: `Option ${tabs.length + 1}`,
+      content: <StackedBarChart categories={categories} series={makeSeries()} />,
+    }
+    setTabs([...tabs, next])
+  }
 
   return (
-    <div className="flex flex-col gap-6">
-      <select
-        aria-label="Dataset"
-        value={current.id}
-        onChange={(e) =>
-          setCurrent(datasets.find((d) => d.id === e.target.value)!)
-        }
-        className="w-48 rounded border p-2"
-      >
-        {datasets.map((d) => (
-          <option key={d.id} value={d.id}>
-            {d.name}
-          </option>
-        ))}
-      </select>
-      <div className="grid grid-cols-2 gap-6">
-        <Card>
-          <CardHeader>
-            <CardTitle>{current.leftLabel}</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <Suspense fallback={<Skeleton className="h-64 w-full" />}>
-              {leftChart}
-            </Suspense>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader>
-            <CardTitle>{current.rightLabel}</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <Suspense fallback={<Skeleton className="h-64 w-full" />}>
-              {rightChart}
-            </Suspense>
-          </CardContent>
-        </Card>
-      </div>
-      <table className="w-full table-auto text-sm">
-        <thead>
-          <tr className="border-b">
-            <th className="p-2 text-left">Metric</th>
-            <th className="p-2 text-left">{current.leftLabel}</th>
-            <th className="p-2 text-left">{current.rightLabel}</th>
-            <th className="p-2 text-left">Δ</th>
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((row) => (
-            <tr key={row.name} className="border-b last:border-0">
-              <td className="p-2">{row.name}</td>
-              <td className="p-2">{row.a}</td>
-              <td className="p-2">{row.b}</td>
-              <td className="p-2">
-                <span
-                  className={`rounded px-2 py-0.5 ${
-                    row.diff >= 0
-                      ? 'bg-green-100 text-green-800'
-                      : 'bg-red-100 text-red-800'
-                  }`}
-                >
-                  {row.diff >= 0 ? '+' : ''}
-                  {row.diff.toFixed(0)}%
-                </span>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+    <div className="flex flex-col gap-4">
+      <header className="flex items-center justify-between gap-2">
+        <select className="rounded border p-2">
+          <option>All options</option>
+        </select>
+        <Button onClick={addTab}>Add tab</Button>
+      </header>
+      <DraggableTabs tabs={tabs} setTabs={setTabs} />
     </div>
-  );
+  )
 }

--- a/components/DraggableTabs.tsx
+++ b/components/DraggableTabs.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import { useState } from 'react'
+import { Reorder } from 'framer-motion'
+import { X } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+export interface TabItem {
+  id: string
+  title: string
+  content: React.ReactNode
+}
+
+interface DraggableTabsProps {
+  tabs: TabItem[]
+  setTabs: (tabs: TabItem[]) => void
+}
+
+export default function DraggableTabs({ tabs, setTabs }: DraggableTabsProps) {
+  const [active, setActive] = useState(tabs[0]?.id)
+
+  const removeTab = (id: string) => {
+    const next = tabs.filter(t => t.id !== id)
+    setTabs(next)
+    if (active === id && next.length) setActive(next[0].id)
+  }
+
+  return (
+    <div className="w-full">
+      <Reorder.Group axis="x" onReorder={setTabs} values={tabs} className="mb-2 flex gap-2">
+        {tabs.map(tab => (
+          <Reorder.Item
+            key={tab.id}
+            value={tab}
+            className={cn(
+              'flex cursor-grab items-center gap-1 rounded-md border px-3 py-1 text-sm',
+              active === tab.id && 'bg-accent text-accent-foreground'
+            )}
+            onPointerDown={e => e.stopPropagation()}
+            onClick={() => setActive(tab.id)}
+          >
+            {tab.title}
+            <button
+              aria-label="Remove tab"
+              className="ml-1"
+              onClick={e => {
+                e.stopPropagation()
+                removeTab(tab.id)
+              }}
+            >
+              <X className="size-3" />
+            </button>
+          </Reorder.Item>
+        ))}
+      </Reorder.Group>
+      <div className="mt-4">
+        {tabs.map(tab => active === tab.id && <div key={tab.id}>{tab.content}</div>)}
+      </div>
+    </div>
+  )
+}

--- a/components/StackedBarChart.tsx
+++ b/components/StackedBarChart.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import React from 'react'
+import { Skeleton } from '@/components/ui/skeleton'
+
+const ReactECharts = React.lazy(() => import('echarts-for-react'))
+
+export interface Series {
+  name: string
+  values: number[]
+}
+
+export interface StackedBarChartProps {
+  categories: string[]
+  series: Series[]
+}
+
+export default function StackedBarChart({ categories, series }: StackedBarChartProps) {
+  const option = React.useMemo(
+    () => ({
+      tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+      legend: {},
+      xAxis: { type: 'category', data: categories },
+      yAxis: { type: 'value' },
+      series: series.map(s => ({
+        name: s.name,
+        type: 'bar',
+        stack: 'total',
+        emphasis: { focus: 'series' },
+        data: s.values,
+      })),
+    }),
+    [categories, series]
+  )
+
+  return (
+    <React.Suspense fallback={<Skeleton className="h-64 w-full" />}>
+      <ReactECharts option={option} style={{ height: '16rem', width: '100%' }} />
+    </React.Suspense>
+  )
+}


### PR DESCRIPTION
## Summary
- implement draggable tabs for stacked bar charts
- create stacked bar chart component using ECharts
- update Compare page with addable, draggable tabs

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_685575f0ec6083228282c77a06581ab9