### PR TITLE
Implement API route for tRPC and tweak client

### DIFF
--- a/__tests__/app.test.tsx
+++ b/__tests__/app.test.tsx
@@ -1,7 +1,13 @@
 import { render, screen } from '@testing-library/react';
 import Page from '../app/page';
+import Providers from '../components/providers';
 
-test('renders project cards', () => {
-  render(<Page />);
-  expect(screen.getAllByRole('link', { name: /enter/i }).length).toBeGreaterThan(0);
+test('renders project cards', async () => {
+  render(
+    <Providers>
+      <Page />
+    </Providers>
+  );
+  const links = await screen.findAllByRole('link', { name: /enter/i });
+  expect(links.length).toBeGreaterThan(0);
 });

--- a/__tests__/e2e/compare.spec.ts
+++ b/__tests__/e2e/compare.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test';
+
+// Landing -> project -> compare flow
+
+test('user can navigate from landing to project to compare', async ({ page }) => {
+  await page.goto('/');
+
+  const firstEnter = page.getByRole('link', { name: /enter/i }).first();
+  await firstEnter.click();
+
+  await expect(page).toHaveURL(/\/projects\//);
+
+  const compareLink = page.getByRole('link', { name: /compare/i }).first();
+  await compareLink.click();
+
+  await expect(page).toHaveURL(/\/compare/);
+  await expect(page.getByText(/tCO2e/)).toBeVisible();
+});

--- a/app/api/trpc/[trpc]/route.ts
+++ b/app/api/trpc/[trpc]/route.ts
@@ -1,0 +1,16 @@
+import { appRouter } from '@/lib/mock-router';
+import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
+import type { NextRequest } from 'next/server';
+
+export const runtime = 'edge';
+
+export async function GET(req: NextRequest) {
+  return fetchRequestHandler({
+    endpoint: '/api/trpc',
+    req,
+    router: appRouter,
+    createContext: () => ({}),
+  });
+}
+
+export { GET as POST };

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -1,42 +1,30 @@
 'use client'
 
-import { useState } from 'react'
-import { Button } from '@/components/ui/button'
-import DraggableTabs, { TabItem } from '@/components/DraggableTabs'
-import StackedBarChart, { Series } from '@/components/StackedBarChart'
+import { Suspense } from 'react'
+import { useSearchParams } from 'next/navigation'
+import { Skeleton } from '@/components/ui/skeleton'
+import useCarbonChart from '@/hooks/use-carbon-chart'
+import { useCarbonResults } from '@/hooks/use-api'
 
-const categories = ['A1-A3', 'A4', 'A5']
-
-function makeSeries(): Series[] {
-  return [
-    { name: 'Concrete', values: categories.map(() => Math.floor(Math.random() * 40 + 10)) },
-    { name: 'Steel', values: categories.map(() => Math.floor(Math.random() * 20 + 5)) },
-  ]
+function ResultGauge({ optionId }: { optionId: string }) {
+  const results = useCarbonResults(optionId)
+  const value = results[0]?.value ?? 0
+  const chart = useCarbonChart('gauge', { value })
+  return chart
 }
 
 export default function ComparePage() {
-  const [tabs, setTabs] = useState<TabItem[]>([
-    { id: 'tab-1', title: 'Option 1', content: <StackedBarChart categories={categories} series={makeSeries()} /> },
-  ])
+  const params = useSearchParams()
+  const optionId = params.get('optionId')
 
-  const addTab = () => {
-    const next: TabItem = {
-      id: `tab-${Date.now()}`,
-      title: `Option ${tabs.length + 1}`,
-      content: <StackedBarChart categories={categories} series={makeSeries()} />,
-    }
-    setTabs([...tabs, next])
-  }
+  if (!optionId) return <p>No option selected</p>
 
   return (
-    <div className="flex flex-col gap-4">
-      <header className="flex items-center justify-between gap-2">
-        <select className="rounded border p-2">
-          <option>All options</option>
-        </select>
-        <Button onClick={addTab}>Add tab</Button>
-      </header>
-      <DraggableTabs tabs={tabs} setTabs={setTabs} />
-    </div>
+    <Suspense fallback={<Skeleton className="h-64 w-full" />}>
+      <div className="flex flex-col gap-4">
+        <h1 className="text-xl font-semibold">Compare</h1>
+        <ResultGauge optionId={optionId} />
+      </div>
+    </Suspense>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,25 +1,37 @@
+'use client';
+
 import Link from 'next/link';
+import { Suspense } from 'react';
 import { Card, CardContent, CardFooter } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useProjects } from '@/hooks/use-api';
 
-const projects = ['Project A', 'Project B', 'Project C'];
-
-export default function Page() {
+function ProjectCards() {
+  const projects = useProjects();
   return (
     <div className="grid gap-4 p-4 sm:grid-cols-2 lg:grid-cols-3">
-      {projects.map((name, i) => (
-        <Card key={name}>
+      {projects.map((p, i) => (
+        <Card key={p.id}>
           <CardContent className="flex h-32 items-center justify-center bg-muted">
             <span className="text-sm text-muted-foreground">Thumbnail {i + 1}</span>
           </CardContent>
           <CardFooter className="justify-between">
-            <span className="font-medium">{name}</span>
+            <span className="font-medium">{p.name}</span>
             <Button asChild size="sm">
-              <Link href={`/projects/${i}`}>Enter</Link>
+              <Link href={`/projects/${p.id}`}>Enter</Link>
             </Button>
           </CardFooter>
         </Card>
       ))}
     </div>
+  );
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<Skeleton className="h-32 w-full" />}>
+      <ProjectCards />
+    </Suspense>
   );
 }

--- a/app/projects/[projectId]/page.tsx
+++ b/app/projects/[projectId]/page.tsx
@@ -2,17 +2,39 @@
 
 import DoughnutChart from '@/components/DoughnutChart'
 import SpeckleViewer from '@/components/SpeckleViewer'
+import Link from 'next/link'
+import { Suspense } from 'react'
+import { Skeleton } from '@/components/ui/skeleton'
+import { useOptions } from '@/hooks/use-api'
 
 interface ProjectPageProps {
   params: { projectId: string }
 }
 
 export default function ProjectPage({ params }: ProjectPageProps) {
+  const { projectId } = params
+
+  function OptionLinks() {
+    const options = useOptions(projectId)
+    return (
+      <ul className="flex flex-col gap-2">
+        {options.map((o) => (
+          <li key={o.id}>
+            <Link className="text-blue-600 underline" href={`/compare?optionId=${o.id}`}>Compare {o.name}</Link>
+          </li>
+        ))}
+      </ul>
+    )
+  }
+
   return (
     <main className="grid grid-cols-8 gap-4">
       <section className="col-span-3 flex flex-col gap-4">
-        <h1 className="text-xl font-semibold">Project {params.projectId}</h1>
+        <h1 className="text-xl font-semibold">Project {projectId}</h1>
         <DoughnutChart />
+        <Suspense fallback={<Skeleton className="h-20 w-full" />}>
+          <OptionLinks />
+        </Suspense>
       </section>
       <section className="col-span-5">
         <SpeckleViewer streamId="mock-stream" modelId="mock-model" />

--- a/hooks/use-api.ts
+++ b/hooks/use-api.ts
@@ -1,28 +1,18 @@
 'use client';
 
-import { useEffect } from 'react';
 import { trpc } from '@/lib/trpc';
 
 export function useProjects() {
   const [data] = trpc.projects.useSuspenseQuery();
-  useEffect(() => {
-    console.log('projects', data);
-  }, [data]);
   return data;
 }
 
 export function useOptions(projectId: string) {
   const [data] = trpc.options.useSuspenseQuery({ projectId });
-  useEffect(() => {
-    console.log('options', data);
-  }, [data]);
   return data;
 }
 
 export function useCarbonResults(optionId: string) {
   const [data] = trpc.carbonResults.useSuspenseQuery({ optionId });
-  useEffect(() => {
-    console.log('results', data);
-  }, [data]);
   return data;
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,7 @@ const customJestConfig = {
     '^@/(.*)$': '<rootDir>/$1',
   },
   testEnvironment: 'jest-environment-jsdom',
+  testPathIgnorePatterns: ['<rootDir>/__tests__/e2e'],
 }
 
 module.exports = createJestConfig(customJestConfig)

--- a/lib/trpc.ts
+++ b/lib/trpc.ts
@@ -1,15 +1,22 @@
 import { createTRPCReact } from '@trpc/react-query';
-import { experimental_localLink } from '@trpc/client';
+import { experimental_localLink, httpBatchLink } from '@trpc/client';
 import type { AppRouter } from './mock-router';
 import { appRouter } from './mock-router';
 
 export const trpc = createTRPCReact<AppRouter>();
 
+const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? '';
+const isBrowser = typeof window !== 'undefined' && !process.env.JEST_WORKER_ID;
+
 export const trpcClient = trpc.createClient({
-  links: [
-    experimental_localLink({
-      router: appRouter,
-      createContext: () => ({}),
-    }),
-  ],
+  links: isBrowser
+    ? [httpBatchLink({ url: `${apiUrl}/api/trpc` })]
+    : [
+        apiUrl
+          ? httpBatchLink({ url: `${apiUrl}/api/trpc` })
+          : experimental_localLink({
+              router: appRouter,
+              createContext: () => ({}),
+            }),
+      ],
 });

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest"
+    "test": "jest",
+    "e2e": "playwright test"
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.3",
@@ -27,9 +28,11 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "tailwind-merge": "^3.3.1",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "ts-node": "^10.9.2"
   },
   "devDependencies": {
+    "@playwright/test": "^1.53.1",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: '__tests__/e2e',
+  use: {
+    baseURL: 'http://localhost:3000',
+  },
+  webServer: {
+    command: 'npx next dev -p 3000',
+    port: 3000,
+    timeout: 120 * 1000,
+    reuseExistingServer: true,
+  },
+});


### PR DESCRIPTION
## Summary
- add tRPC route under `app/api/trpc` for HTTP calls
- update `trpcClient` to use HTTP in the browser and local link in tests
- configure Playwright with a base URL

## Testing
- `npm test`
- `npx playwright test` *(fails: Test timeout of 30000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_b_68557cd8b9d88322887e56477fd70fcb