### PR TITLE
Fix build errors for strict TS

### DIFF
--- a/components/DraggableTabs.tsx
+++ b/components/DraggableTabs.tsx
@@ -36,14 +36,16 @@ export default function DraggableTabs({ tabs, setTabs }: DraggableTabsProps) {
               'flex cursor-grab items-center gap-1 rounded-md border px-3 py-1 text-sm',
               active === tab.id && 'bg-accent text-accent-foreground'
             )}
-            onPointerDown={e => e.stopPropagation()}
+            onPointerDown={(e: React.PointerEvent<HTMLDivElement>) =>
+              e.stopPropagation()
+            }
             onClick={() => setActive(tab.id)}
           >
             {tab.title}
             <button
               aria-label="Remove tab"
               className="ml-1"
-              onClick={e => {
+              onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
                 e.stopPropagation()
                 removeTab(tab.id)
               }}

--- a/components/SpeckleViewer.tsx
+++ b/components/SpeckleViewer.tsx
@@ -2,13 +2,15 @@
 
 import { useState } from 'react'
 import dynamic from 'next/dynamic'
+// Dynamic import can't infer ViewerProps type correctly, so use any
 import { Maximize2, Minimize2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 
-const Viewer = dynamic(() => import('@speckle/viewer-react').then(m => m.Viewer), {
-  ssr: false
-})
+const Viewer = dynamic(
+  () => import('@speckle/viewer-react').then((m) => m.Viewer),
+  { ssr: false },
+) as React.ComponentType<any>
 
 export interface SpeckleViewerProps {
   streamId: string

--- a/lib/trpc.ts
+++ b/lib/trpc.ts
@@ -16,7 +16,7 @@ export const trpcClient = trpc.createClient({
           ? httpBatchLink({ url: `${apiUrl}/api/trpc` })
           : experimental_localLink({
               router: appRouter,
-              createContext: () => ({}),
+              createContext: async () => ({}),
             }),
       ],
 });


### PR DESCRIPTION
## Summary
- fix pointer event types in `DraggableTabs`
- cast dynamic `SpeckleViewer` component to avoid TS errors
- return async context in trpc client

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npx -y lighthouse http://example.com` *(fails: Unable to connect to Chrome)*

------
https://chatgpt.com/codex/tasks/task_b_685589beb1d88322be277f2cb7710e6d