### PR TITLE
fix: remove obsolete export command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
           node-version: 20
           cache: 'npm'
       - run: npm ci
-      - run: npm run build && npm run export
+      - run: npm run build
       - uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ Constraints: ≤ 120 LOC per file; follow Prettier; use British English in c
 | `npm run lint`      | ESLint + Prettier check                |
 | `npm test`          | Unit tests via Jest                    |
 | `npm run build`     | Production build (`.next/`)            |
-| `npm run export`    | Static export (for GitHub Pages)       |
 | `npm run storybook` | Visual test components (optional)      |
 
 ---
@@ -118,8 +117,8 @@ Constraints: ≤ 120 LOC per file; follow Prettier; use British English in c
 ### GitHub Pages
 
 ```yaml
-# .github/workflows/deploy-pages.yml (excerpt)
-- run: npm run export
+# .github/workflows/deploy.yml (excerpt)
+- run: npm run build
 - run: npx gh-pages -d out
 ```
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "export": "next export",
     "start": "next start",
     "lint": "next lint",
     "test": "jest",


### PR DESCRIPTION
## Summary
- drop `next export` script
- run `npm run build` for deployment
- update docs and workflow snippet

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6855985912008322941802f759713a8d