### PR TITLE
Fix GitHub Actions artifact upload

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run build && npx next export
-      - uses: actions/upload-pages-artifact@v2
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: ./out
           name: github-pages


### PR DESCRIPTION
## Summary
- bump `actions/upload-pages-artifact` to `v3` to avoid deprecated `upload-artifact` version

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68597850b414832296983b6c18b451d0