### PR TITLE
fix: update static export config

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: 20
           cache: 'npm'
       - run: npm ci
-      - run: npm run build && npx next export
+      - run: npm run build
       - uses: actions/upload-pages-artifact@v3
         with:
           path: ./out

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  output: 'export',
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- update Next.js config to use `output: 'export'`
- remove deprecated `next export` command from CI workflow

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_685979ced5048322be359879b6c478b6