### PR TITLE
Add generateStaticParams for project pages

### DIFF
--- a/app/projects/[projectId]/layout.tsx
+++ b/app/projects/[projectId]/layout.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from 'react'
+import { appRouter } from '@/lib/mock-router'
+
+export async function generateStaticParams() {
+  const caller = appRouter.createCaller({})
+  const projects = await caller.projects()
+  return projects.map(p => ({ projectId: p.id }))
+}
+
+export default function ProjectLayout({ children }: { children: ReactNode }) {
+  return children
+}


### PR DESCRIPTION
## Summary
- ensure Next.js can statically export dynamic `/projects/[projectId]` route
- implement `generateStaticParams` in a new server layout

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68598007a64c83228ec5108f0293d1e0