### PR TITLE
Fix Tailwind static export configuration

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
     darkMode: ['class'],
-    content: ['app/**/*.{ts,tsx}'],
+    content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
   theme: {
   	extend: {
   		borderRadius: {


### PR DESCRIPTION
## Summary
- add `components` directory to Tailwind CSS `content` globs

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npx -y serve out` *(fails: interactive server run not accessible in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_685984a84ed88322a886641d72fed5ac