### PR TITLE
fix: set base path for pages

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,27 +2,27 @@
 
 import Link from 'next/link';
 import { Suspense } from 'react';
-import { Card, CardContent, CardFooter } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useProjects } from '@/hooks/use-api';
 
-function ProjectCards() {
+function ProjectGrid() {
   const projects = useProjects();
   return (
-    <div className="grid gap-4 p-4 sm:grid-cols-2 lg:grid-cols-3">
-      {projects.map((p, i) => (
-        <Card key={p.id}>
-          <CardContent className="flex h-32 items-center justify-center bg-muted">
-            <span className="text-sm text-muted-foreground">Thumbnail {i + 1}</span>
-          </CardContent>
-          <CardFooter className="justify-between">
-            <span className="font-medium">{p.name}</span>
+    <div className="grid gap-6 p-8 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+      {projects.map((p) => (
+        <div
+          key={p.id}
+          className="rounded-xl bg-white/10 p-6 shadow transition hover:bg-emerald/10"
+        >
+          <div className="mb-4 h-32 w-full rounded bg-charcoal/20" />
+          <div className="flex flex-col items-center gap-2">
+            <span className="text-center font-medium">{p.name}</span>
             <Button asChild size="sm">
               <Link href={`/projects/${p.id}`}>Enter</Link>
             </Button>
-          </CardFooter>
-        </Card>
+          </div>
+        </div>
       ))}
     </div>
   );
@@ -31,7 +31,7 @@ function ProjectCards() {
 export default function Page() {
   return (
     <Suspense fallback={<Skeleton className="h-32 w-full" />}>
-      <ProjectCards />
+      <ProjectGrid />
     </Suspense>
   );
 }

--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,9 @@
 const nextConfig = {
   reactStrictMode: true,
   output: 'export',
+  basePath: '/Carbon101',
+  assetPrefix: '/Carbon101',
+  trailingSlash: true,
 };
 
 module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "export": "next export",
     "start": "next start",
     "lint": "next lint",
     "test": "jest",


### PR DESCRIPTION
## Summary
- configure `basePath` and `assetPrefix` for GitHub Pages
- add `export` script
- improve project grid styling on landing page

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_685a683f638483229145c37fe76ef2cf