### PR TITLE
Implement hover-to-open sidebar behavior

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -26,7 +26,7 @@ export default function Sidebar() {
   return (
     <aside
       className={cn(
-        "flex flex-col border-r bg-charcoal text-white transition-all duration-300",
+        "relative flex flex-col border-r bg-charcoal text-white transition-all duration-300",
         open ? "w-60" : "w-16"
       )}
     >
@@ -80,6 +80,12 @@ export default function Sidebar() {
       <div className="mt-auto p-4">
         <Settings aria-hidden="true" className="size-5" />
       </div>
+      {!open && (
+        <div
+          className="absolute left-0 top-0 z-50 h-full w-2"
+          onMouseEnter={() => setOpen(true)}
+        />
+      )}
     </aside>
   );
 }


### PR DESCRIPTION
## Summary
- update Sidebar to maintain open state and reveal on hover when collapsed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685a70d1d6c88322aee3376159ea9e40