### PR TITLE
Fix deploy workflow push permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- allow GH Pages workflow to push to repo

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_685a85b192a48322ae80bf8936bad99a