### PR TITLE
Persist sidebar state

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Link from "next/link";
 import {
   User,
@@ -22,6 +22,17 @@ const links = [
 export default function Sidebar() {
   const [open, setOpen] = useState(true);
   const [menuOpen, setMenuOpen] = useState(false);
+
+  useEffect(() => {
+    const saved = localStorage.getItem("sidebarOpen");
+    if (saved !== null) {
+      setOpen(JSON.parse(saved));
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem("sidebarOpen", JSON.stringify(open));
+  }, [open]);
 
   return (
     <aside


### PR DESCRIPTION
## Summary
- persist sidebar state to localStorage in `Sidebar`

## Testing
- `npm test` *(fails: jest not found)*
- `npx playwright test` *(fails: playwright missing)*

------
https://chatgpt.com/codex/tasks/task_b_685ab4e684d08322b1c4cc5793a876ca