### PR TITLE
feat: simplify home UI

### DIFF
--- a/__tests__/app.test.tsx
+++ b/__tests__/app.test.tsx
@@ -1,13 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import Page from '../app/page';
-import Providers from '../components/providers';
 
-test('renders project cards', async () => {
-  render(
-    <Providers>
-      <Page />
-    </Providers>
-  );
-  const links = await screen.findAllByRole('link', { name: /enter/i });
-  expect(links.length).toBeGreaterThan(0);
+test('renders hello world', () => {
+  render(<Page />);
+  expect(screen.getByText(/hello world/i)).toBeInTheDocument();
 });

--- a/__tests__/e2e/compare.spec.ts
+++ b/__tests__/e2e/compare.spec.ts
@@ -1,18 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-// Landing -> project -> compare flow
-
-test('user can navigate from landing to project to compare', async ({ page }) => {
+test('landing page shows hello world', async ({ page }) => {
   await page.goto('/');
-
-  const firstEnter = page.getByRole('link', { name: /enter/i }).first();
-  await firstEnter.click();
-
-  await expect(page).toHaveURL(/\/projects\//);
-
-  const compareLink = page.getByRole('link', { name: /compare/i }).first();
-  await compareLink.click();
-
-  await expect(page).toHaveURL(/\/compare/);
-  await expect(page.getByText(/tCO2e/)).toBeVisible();
+  await expect(page.getByText(/hello world/i)).toBeVisible();
 });

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,5 @@
 import '../styles/globals.css';
 import type { ReactNode } from 'react';
-import Sidebar from '@/components/Sidebar';
-import Providers from '@/components/providers';
-import PageTransition from '@/components/page-transition';
 import { Inter, Fira_Code } from 'next/font/google';
 
 const inter = Inter({
@@ -19,20 +16,9 @@ const firaCode = Fira_Code({
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html
-      lang="en"
-      className={`${inter.variable} ${firaCode.variable}`}
-      suppressHydrationWarning
-    >
-      <body className="font-sans antialiased">
-        <Providers>
-          <div className="grid min-h-screen grid-cols-[auto,1fr]">
-            <Sidebar />
-            <div className="bg-background">
-              <PageTransition>{children}</PageTransition>
-            </div>
-          </div>
-        </Providers>
+    <html lang="en" className={`${inter.variable} ${firaCode.variable}`}> 
+      <body className="font-sans antialiased bg-background flex items-center justify-center min-h-screen">
+        {children}
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,37 +1,7 @@
-'use client';
-
-import Link from 'next/link';
-import { Suspense } from 'react';
-import { Button } from '@/components/ui/button';
-import { Skeleton } from '@/components/ui/skeleton';
-import { useProjects } from '@/hooks/use-api';
-
-function ProjectGrid() {
-  const projects = useProjects();
-  return (
-    <div className="grid gap-6 p-8 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-      {projects.map((p) => (
-        <div
-          key={p.id}
-          className="rounded-xl bg-white/10 p-6 shadow transition hover:bg-emerald/10"
-        >
-          <div className="mb-4 h-32 w-full rounded bg-charcoal/20" />
-          <div className="flex flex-col items-center gap-2">
-            <span className="text-center font-medium">{p.name}</span>
-            <Button asChild size="sm">
-              <Link href={`/projects/${p.id}`}>Enter</Link>
-            </Button>
-          </div>
-        </div>
-      ))}
-    </div>
-  );
-}
-
 export default function Page() {
   return (
-    <Suspense fallback={<Skeleton className="h-32 w-full" />}>
-      <ProjectGrid />
-    </Suspense>
+    <main className="flex min-h-screen items-center justify-center">
+      <h1 className="text-2xl font-semibold">Hello World</h1>
+    </main>
   );
 }


### PR DESCRIPTION
## Summary
- render a minimal Hello World page
- strip out Sidebar, Providers, and animations from layout
- update tests for the new UI

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e` *(fails: browser not installed)*

------
https://chatgpt.com/codex/tasks/task_b_685ac10f15048322a3a95a304116292e