### PR TITLE
Fix e2e test

### DIFF
--- a/__tests__/e2e/compare.spec.ts
+++ b/__tests__/e2e/compare.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
 test('landing page shows hello world', async ({ page }) => {
-  await page.goto('/');
+  await page.goto('/Carbon101/');
   await expect(page.getByText(/hello world/i)).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- adjust Playwright test to use `/Carbon101/` base path

## Testing
- `npm run e2e`

------
https://chatgpt.com/codex/tasks/task_b_685ac4e87748832296668dc3c4357797