### PR TITLE
feat: add basic forge viewer component

### DIFF
--- a/components/forge-viewer.tsx
+++ b/components/forge-viewer.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { useEffect, useRef } from 'react';
+
+function ForgeViewerInner() {
+  const container = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let viewer: Autodesk.Viewing.GuiViewer3D | undefined;
+
+    const load = async () => {
+      await import('forge-viewer');
+      Autodesk.Viewing.Initializer({}, () => {
+        if (container.current) {
+          viewer = new Autodesk.Viewing.GuiViewer3D(container.current);
+          viewer.start();
+        }
+      });
+    };
+
+    load();
+    return () => viewer?.finish();
+  }, []);
+
+  return <div ref={container} className="h-96 w-full" />;
+}
+
+export default dynamic(() => Promise.resolve(ForgeViewerInner), { ssr: false });


### PR DESCRIPTION
## Summary
- use `next/dynamic` to load the Forge Viewer only on the client
- initialise viewer with `Autodesk.Viewing.Initializer`
- mount `GuiViewer3D` to a div container

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68627b5b3f4883228df13ce6045a81e6