### PR TITLE
feat: switch to Autodesk viewer

### DIFF
--- a/app/projects/[projectId]/page.tsx
+++ b/app/projects/[projectId]/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import DoughnutChart from '@/components/DoughnutChart'
-import SpeckleViewer from '@/components/SpeckleViewer'
+import AutodeskViewer from '@/components/autodesk-viewer'
 import Link from 'next/link'
 import { Suspense } from 'react'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -37,7 +37,7 @@ export default function ProjectPage({ params }: ProjectPageProps) {
         </Suspense>
       </section>
       <section className="col-span-5">
-        <SpeckleViewer streamId="mock-stream" modelId="mock-model" />
+        <AutodeskViewer modelUrn="mock-urn" token="mock-token" />
       </section>
     </main>
   )

--- a/components/autodesk-viewer.tsx
+++ b/components/autodesk-viewer.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+
+export interface AutodeskViewerProps {
+  modelUrn: string
+  token: string
+}
+
+export default function AutodeskViewer({ modelUrn, token }: AutodeskViewerProps) {
+  const viewerDiv = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    let viewer: Autodesk.Viewing.GuiViewer3D | undefined
+    const opts = { env: 'AutodeskProduction', accessToken: token }
+
+    Autodesk.Viewing.Initializer(opts, () => {
+      if (!viewerDiv.current) return
+      viewer = new Autodesk.Viewing.GuiViewer3D(viewerDiv.current)
+      viewer.start()
+      viewer.loadModel(`urn:${modelUrn}`)
+    })
+
+    return () => viewer?.finish()
+  }, [modelUrn, token])
+
+  return <div ref={viewerDiv} className="h-full w-full" />
+}


### PR DESCRIPTION
## Summary
- swap Speckle viewer import for Autodesk viewer
- provide URN and token props
- implement minimal Autodesk Viewer wrapper

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68627d1fbb1c8322a6fe62eda3f017ea